### PR TITLE
Only download the mmonit package if it has not already been downloaded.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,6 +12,7 @@ remote_file src_filepath do
   owner "root"
   group "root"
   mode 00644
+  not_if { ::File.exists?(src_filepath) }
 end
 
 bash "extract_source" do


### PR DESCRIPTION
The current recipe does not check if the package has already been downloaded, and downloads it every time the chef-client is run. The http://mmonit.com/ web site returns a 40x error preventing more than one download a day.
Mentioned on twitter: https://twitter.com/SDRycroft/status/623080167104245760
