### PR TITLE
Systemd support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,3 +14,10 @@ default["mmonit"]["db"]["reapConnections"] = "300"
 default["mmonit"]["proxy_scheme"] = nil
 default["mmonit"]["proxy_name"] = nil
 default["mmonit"]["proxy_port"] = nil
+
+
+default['mmonit']['init_style'] = if node['platform'] == 'ubuntu' && node['platform_version'].to_f <= 14.04
+                                   'upstart'
+                                 else
+                                   node['init_package']
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,15 +33,27 @@ template "#{node['mmonit']['dir']}/conf/server.xml" do
   notifies :restart, "service[mmonit]"
 end
 
-template "/etc/init/mmonit.conf" do
-  source "mmonit-upstart.conf.erb"
-  owner  "root"
-  group  "root"
-  mode   "0644"
+# Upstart
+if node['mmonit']['init_style'] == 'upstart'
+  template "/etc/init/mmonit.conf" do
+    source "mmonit-upstart.conf.erb"
+    owner  "root"
+    group  "root"
+    mode   "0644"
+  end
+end
+
+# Systemd
+if node['mmonit']['init_style'] == 'systemd'
+  template "/etc/systemd/system/mmonit.service" do
+    source "mmonit.service.erb"
+    owner "root"
+    group "root"
+    mode  "0644"
+  end
 end
 
 service "mmonit" do
-  provider Chef::Provider::Service::Upstart
   supports status: true, restart: true, reload: true
   action   [:enable, :start]
 end

--- a/templates/default/mmonit.service.erb
+++ b/templates/default/mmonit.service.erb
@@ -1,0 +1,12 @@
+[Unit]
+Description=M/Monit system monitoring
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=<%=node["mmonit"]["dir"] %>
+ExecStart=<%=node["mmonit"]["dir"] %>/bin/mmonit -i
+ExecStop=<%=node["mmonit"]["dir"] %>/bin/mmonit stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I think upstart is quite old already, we should focus on systemd support. This should also allow to work with other non-ubuntu distros.

I'm not proposing a removal of upstart, but supporting both. It exists a better solution if we discriminate which one is supported on machine, but should work better for now.